### PR TITLE
Update PaginateItems.svelte to support optional / default page param

### DIFF
--- a/src/lib/PaginateItems.svelte
+++ b/src/lib/PaginateItems.svelte
@@ -10,7 +10,7 @@
   import { natural } from './utils/natural.js'
 
   export let lastPage: number
-  export let slug: `[${string}]` | `[${string}=${string}]`
+  export let slug: `[[${string}]]` | `[${string}]` | `[${string}=${string}]` | `[[${string}=${string}]]`
   export let sideSize = 2
   export let centerSize = 3
   export let previousLabel: string | null = '＜ Previous'
@@ -20,7 +20,9 @@
   export let disableKeyboardNavigation = false
 
   $: routeId = $page.route.id
-  $: key = slug.slice(1, slug.includes('=') ? slug.indexOf('=') : -1)
+  $: key = slug.startsWith('[[') 
+      ? slug.slice(2, slug.includes('=') ? slug.indexOf('=') : -2) 
+      : slug.slice(1, slug.includes('=') ? slug.indexOf('=') : -1)
   $: current = convertInt($page.params[key], 1)
 
   $: last = Math.ceil(clamp(lastPage, 1, Infinity))


### PR DESCRIPTION
e.g. if the initial page number is to be implied, [[page=int]]

https://svelte.dev/docs/kit/advanced-routing#Optional-parameters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded the `slug` property in the pagination component to support additional string formats, enhancing flexibility in usage.
  
- **Bug Fixes**
	- Updated logic for deriving the `key` from the `slug` to ensure accurate handling of the new formats without affecting existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->